### PR TITLE
Fixed build on ember-cli > 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 const path = require('path');
 const Funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
+const DEFAULT_NODE_MODULES_PATH = 'node_modules';
 
 module.exports = {
   name: 'ember-cli-bootstrap-colorpicker',
@@ -21,17 +22,17 @@ module.exports = {
   },
 
   getColorpickerStylesPath() {
-    let nodeModulesPath = this.app.project.nodeModulesPath;
+    let nodeModulesPath = this.app.project.nodeModulesPath || DEFAULT_NODE_MODULES_PATH;
     return path.join(nodeModulesPath, 'bootstrap-colorpicker', 'dist', 'css');
   },
 
   getColorpickerJavascriptsPath() {
-    let nodeModulesPath = this.app.project.nodeModulesPath;
+    let nodeModulesPath = this.app.project.nodeModulesPath || DEFAULT_NODE_MODULES_PATH;
     return path.join(nodeModulesPath, 'bootstrap-colorpicker', 'dist', 'js');
   },
 
   getColorpickerImagePath() {
-    let nodeModulesPath = this.app.project.nodeModulesPath;
+    let nodeModulesPath = this.app.project.nodeModulesPath || DEFAULT_NODE_MODULES_PATH;
     return path.join(nodeModulesPath, 'bootstrap-colorpicker', 'dist', 'img');
   },
 


### PR DESCRIPTION
According to this commit https://github.com/ember-cli/ember-cli/commit/26111a6677989ff88846adc49edb57d7ea3ff5b6 nodeModulesPath is no longer available.