### PR TITLE
Ensure addon can build in ember engines

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,11 @@ module.exports = {
     let pkg = parts[0];
     let root = '';
     // when an engine is building, this.app is undefined...
+    // but this.project seems to be consistently defined.
     if (this.project && this.project.root) {
       root = this.project.root;
     } else {
-      console.error(`ember-cli-bootstrap-colorpicker unable to locate the project root!`);
+      console.error(`ember-cli-bootstrap-colorpicker unable to locate the project root!`); // eslint-disable-line no-console
     }
 
 

--- a/index.js
+++ b/index.js
@@ -21,9 +21,19 @@ module.exports = {
   },
 
   resolvePackagePath(pkgPath) {
+
     let parts = pkgPath.split('/');
     let pkg = parts[0];
-    let result = path.dirname(resolve.sync(`${pkg}/package.json`, { basedir: this.app.project.root }));
+    let root = '';
+    // when an engine is building, this.app is undefined...
+    if (this.project && this.project.root) {
+      root = this.project.root;
+    } else {
+      console.error(`ember-cli-bootstrap-colorpicker unable to locate the project root!`);
+    }
+
+
+    let result = path.dirname(resolve.sync(`${pkg}/package.json`, { basedir: root }));
 
     // add sub folders to path
     if (parts.length > 1) {


### PR DESCRIPTION
I'm doing some work moving parts of our app into `ember-engine`s and when the engine tried to build this addon, it would fail because `this.app` was undefined in the `resolvePackagePath` calls in `index.js`.

While I'm not 100% sure this is the _best_ solution, this does seem to work for both engines and normal ember app builds. For now, we are running off this branch in my fork but unless someone has a better way to implement this, it would be great to get this merged & have a release.

Thanks!